### PR TITLE
feat: add selectFocusedOnSubmit option

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -140,6 +140,13 @@ export interface UseSelectOptions<Value, Multiple extends boolean = true> {
    */
   multiple?: Multiple;
   /**
+   * Select the currently focused option when submitting (press enter), if no other options are already selected.
+   *
+   * @defaultValue
+   * `false`
+   */
+  selectFocusedOnSubmit?: boolean;
+  /**
    * validate when submitting (press enter). Only when true is returned will the validation pass.
    *
    * @defaultValue

--- a/src/useSelect.ts
+++ b/src/useSelect.ts
@@ -90,6 +90,7 @@ export function useSelect<Value, Multiple extends boolean>(
     options,
     loop = false,
     multiple = true,
+    selectFocusedOnSubmit = false,
     filter = true,
     required = false,
     defaultValue,
@@ -285,8 +286,11 @@ export function useSelect<Value, Multiple extends boolean>(
       if (status !== SelectStatus.LOADED) {
         return;
       }
-      if (!multiple) {
-        // For single selection, directly use <enter> to select
+      if (
+        !multiple ||
+        (selectFocusedOnSubmit && selections.current.length === 0)
+      ) {
+        // For single selection or if no option is selected and selectFocusedOnSubmit is enabled, directly use <enter> to select
         handleSelect(rl);
       }
       await submit();

--- a/tests/index.spec.ts
+++ b/tests/index.spec.ts
@@ -184,6 +184,26 @@ describe('inquirer-select-pro', () => {
       );
     });
 
+    it('should get the result when press <enter> in multi selection mode when selectFocusedOnSubmit=true', async () => {
+      await renderPrompt({
+        message,
+        options: top100Films,
+        multiple: true,
+        pageSize: 3,
+        selectFocusedOnSubmit: true,
+      });
+      events.keypress('enter');
+      await expect(answer).resolves.toMatchInlineSnapshot(
+        `\
+[
+  "The Shawshank Redemption",
+]`,
+      );
+      expect(getScreen()).toMatchInlineSnapshot(
+        `"? Choose movie: The Shawshank Redemption (1994)"`,
+      );
+    });
+
     it('should be possible to filter in radio selection mode', async () => {
       await renderPrompt({
         message,


### PR DESCRIPTION
Add an option to automatically select the currently focused option when pressing enter and no other options are already selected (when `multiple=true`).